### PR TITLE
(minor) some indentation and coding style fixes

### DIFF
--- a/app/code/community/Kkoepke/CheckoutAddressFix/Block/Onepage/Billing.php
+++ b/app/code/community/Kkoepke/CheckoutAddressFix/Block/Onepage/Billing.php
@@ -1,26 +1,24 @@
 <?php
-class Kkoepke_CheckoutAddressFix_Block_Onepage_Billing extends Mage_Checkout_Block_Onepage_Billing {
+class Kkoepke_CheckoutAddressFix_Block_Onepage_Billing extends Mage_Checkout_Block_Onepage_Billing
+{
+    protected $_address;
+    protected $_taxvat;
 
-	protected $_address;
-	protected $_taxvat;
+    public function getAddress() {
+        if(is_null($this->_address)) {
+            if($this->isCustomerLoggedIn()) {
+                $this->_address = $this->getQuote()->getBillingAddress();
+                if(!$this->_address->getFirstname()) {
+                    $this->_address->setFirstname($this->getQuote()->getCustomer()->getFirstname());
+                }
+                if(!$this->_address->getLastname()) {
+                    $this->_address->setLastname($this->getQuote()->getCustomer()->getLastname());
+                }
+            } else {
+                $this->_address = $this->getQuote()->getBillingAddress();
+            }
+        }
 
-	public function getAddress() {
-		if(is_null($this->_address)) {
-			if($this->isCustomerLoggedIn()) {
-				$this->_address = $this->getQuote()->getBillingAddress();
-				if(!$this->_address->getFirstname()) {
-					$this->_address->setFirstname($this->getQuote()->getCustomer()->getFirstname());
-				}
-				if(!$this->_address->getLastname()) {
-					$this->_address->setLastname($this->getQuote()->getCustomer()->getLastname());
-				}
-			} else {
-				$this->_address = $this->getQuote()->getBillingAddress();
-			}
-		}
-
-		return $this->_address;
-	}
-
+        return $this->_address;
+    }
 }
-?>

--- a/app/code/community/Kkoepke/CheckoutAddressFix/Block/Onepage/Shipping.php
+++ b/app/code/community/Kkoepke/CheckoutAddressFix/Block/Onepage/Shipping.php
@@ -1,6 +1,6 @@
 <?php
-class Kkoepke_CheckoutAddressFix_Block_Onepage_Shipping extends Mage_Checkout_Block_Onepage_Shipping {
-
+class Kkoepke_CheckoutAddressFix_Block_Onepage_Shipping extends Mage_Checkout_Block_Onepage_Shipping
+{
     public function getAddress()
     {
         if (is_null($this->_address)) {
@@ -9,6 +9,4 @@ class Kkoepke_CheckoutAddressFix_Block_Onepage_Shipping extends Mage_Checkout_Bl
 
         return $this->_address;
     }
-
 }
-?>

--- a/app/code/community/Kkoepke/CheckoutAddressFix/etc/config.xml
+++ b/app/code/community/Kkoepke/CheckoutAddressFix/etc/config.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <config>
-	<modules>
-		<Kkoepke_CheckoutAddressFix>
-			<version>0.1.0</version>
-		</Kkoepke_CheckoutAddressFix>
-		<depends>Mage_Checkout</depends>
-	</modules>
-	<global>
-		<blocks>
-			<checkout>
-				<rewrite>
-					<onepage_billing>Kkoepke_CheckoutAddressFix_Block_Onepage_Billing</onepage_billing>
+    <modules>
+        <Kkoepke_CheckoutAddressFix>
+            <version>0.1.0</version>
+        </Kkoepke_CheckoutAddressFix>
+        <depends>Mage_Checkout</depends>
+    </modules>
+    <global>
+        <blocks>
+            <checkout>
+                <rewrite>
+                    <onepage_billing>Kkoepke_CheckoutAddressFix_Block_Onepage_Billing</onepage_billing>
                     <onepage_shipping>Kkoepke_CheckoutAddressFix_Block_Onepage_Shipping</onepage_shipping>
-				</rewrite>
-			</checkout>
-		</blocks>
-	</global>
+                </rewrite>
+            </checkout>
+        </blocks>
+    </global>
 </config>


### PR DESCRIPTION
Applied Magento coding style:
- replaced tabs by spaces
- removed closing PHP tags
- move opening curly brakes of classes to a new line
