### PR TITLE
Update config.xml - Wrong Tag Order

### DIFF
--- a/app/code/community/Kkoepke/CheckoutAddressFix/etc/config.xml
+++ b/app/code/community/Kkoepke/CheckoutAddressFix/etc/config.xml
@@ -3,8 +3,8 @@
     <modules>
         <Kkoepke_CheckoutAddressFix>
             <version>0.1.0</version>
+            <depends>Mage_Checkout</depends>
         </Kkoepke_CheckoutAddressFix>
-        <depends>Mage_Checkout</depends>
     </modules>
     <global>
         <blocks>


### PR DESCRIPTION
Search for some time where the module output to disable "depends" under System > Config > Admin > Extended came from ^^

Better to include it correctly under the modules hive, as otherwise it's read as another module name ;)

![screen shot 2015-05-07 at 14 18 36](https://cloud.githubusercontent.com/assets/1413291/7515119/53b98366-f4c4-11e4-9ea1-1ad2cb44c85d.png)